### PR TITLE
Add copy functionality with rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,10 +3,19 @@
 version = 4
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "cfg-if"
@@ -28,9 +37,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "ppv-lite86"
@@ -43,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -95,17 +110,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rust"
 version = "0.1.0"
 dependencies = [
  "rand",
+ "regex",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 rand = "0.9.2"
+regex = "1.11.1"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -6,7 +6,6 @@ use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
 
-
 const PREFIX_LENGTH: u32 = 6;
 const FILE_NAME_REGEX_STR: &str = r"(?<prefix>.+)_(?<index>\d+)\.(?<extension>\w+)$";
 
@@ -24,7 +23,6 @@ fn _get_image_extensions() -> HashSet<String> {
     image_extensions
 }
 
-
 /// read a line from stdin, strips the leading and trailing whitespace
 fn _read_input() -> Result<String, io::Error> {
     let mut buffer = String::new();
@@ -40,12 +38,11 @@ fn _read_input() -> Result<String, io::Error> {
     }
 }
 
-
 /// prompts the user for a new prefix, and returns it
 ///
 /// if the user enters in `.`, read the directory name as the new prefix
 fn _get_new_prefix() -> String {
-    println!("What should the new prefix be?");
+    println!("What should the new prefix be? Type `.` for the current directory.");
     let mut new_prefix = match _read_input() {
         Ok(prefix) => prefix,
         Err(e) => panic!("Error: failed to read new prefix: {}", e),
@@ -68,7 +65,6 @@ fn _get_new_prefix() -> String {
     new_prefix
 }
 
-
 /// Returns the file extension
 fn _get_file_extension(filename: &String) -> String {
     let filename_path = Path::new(filename);
@@ -79,11 +75,10 @@ fn _get_file_extension(filename: &String) -> String {
     extension
 }
 
-
 /// Grabs all the images in the current directory, filters out the ones that aren't images
 ///
 /// Sorts the files alphabetically
-fn get_images(img_extensions: HashSet<String>) -> Vec<String> {
+fn _get_images(img_extensions: HashSet<String>) -> Vec<String> {
     let mut image_files: Vec<String> = Vec::new();
     let entries: fs::ReadDir = match fs::read_dir(".") {
         Ok(entries) => entries,
@@ -111,7 +106,6 @@ fn get_images(img_extensions: HashSet<String>) -> Vec<String> {
     image_files
 }
 
-
 /// Renames a single image to a new prefix and index
 fn rename_image(image_name: String, new_prefix: &str, index: u32) {
     if index > 9999 {
@@ -131,7 +125,6 @@ fn rename_image(image_name: String, new_prefix: &str, index: u32) {
     };
 }
 
-
 /// Renames all given photos to a new prefix and index
 fn _rename_all_photos(image_files: Vec<String>, new_prefix: &String, starting_index: &String) {
     let mut index: u32 = starting_index.parse().unwrap();
@@ -141,14 +134,12 @@ fn _rename_all_photos(image_files: Vec<String>, new_prefix: &String, starting_in
     }
 }
 
-
 /// Generates a random prefix of a given length
 fn _generate_random_prefix(length: u32) -> String {
     let length_us = usize::try_from(length).unwrap();
     let rand_prefix: String = Alphanumeric.sample_string(&mut rand::rng(), length_us);
     rand_prefix
 }
-
 
 /// Renames all photo and video files in the current directory.
 ///
@@ -169,20 +160,19 @@ fn rename() {
         new_prefix, starting_index,
     );
     // grab all photo and video files in the current directory
-    let mut image_files: Vec<String> = get_images(_get_image_extensions());
+    let mut image_files: Vec<String> = _get_images(_get_image_extensions());
     dbg!(&image_files);
 
     // rename each file to a random prefix. This ensures that if we keep the same prefix and just
     // update the numbers, nothing will be overwritten
     let rand_prefix: String = _generate_random_prefix(PREFIX_LENGTH);
     _rename_all_photos(image_files, &rand_prefix, &starting_index);
-    image_files = get_images(_get_image_extensions());
+    image_files = _get_images(_get_image_extensions());
     _rename_all_photos(image_files, &new_prefix, &starting_index);
 }
 
-
 /// given a filename, extract out the prefix, file number, and extension
-fn parse_filename(filename: &String) -> (String, u32, String) {
+fn _parse_filename(filename: &String) -> (String, u32, String) {
     let re = Regex::new(FILE_NAME_REGEX_STR).unwrap();
     let caps = re.captures(filename).unwrap();
     let prefix = caps.get(1).unwrap().as_str().to_string();
@@ -193,7 +183,7 @@ fn parse_filename(filename: &String) -> (String, u32, String) {
 
 /// Copies the images in the current directory.
 fn copy() {
-    println!("Which file contains the list of numbers to copy?");
+    println!("Which file contains the list of numbers to copy? Type `.` for the default file.");
     let file_name = match _read_input() {
         Ok(input) => {
             if input == "." {
@@ -219,7 +209,7 @@ fn copy() {
 
     let reader = BufReader::new(file);
     let image_extensions = _get_image_extensions();
-    let available_images = get_images(image_extensions);
+    let available_images = _get_images(image_extensions);
 
     // Create a HashSet of the numbers in the file
     let mut file_numbers: HashSet<u32> = HashSet::new();
@@ -248,7 +238,7 @@ fn copy() {
     for image in available_images {
         // iterate through each available image and see if it should be copied
         // easier to do this way rather than constructing the full image name from the index
-        let (prefix, index, extension) = parse_filename(&image);
+        let (prefix, index, extension) = _parse_filename(&image);
         if !file_numbers.contains(&index) {
             continue;
         }
@@ -265,6 +255,15 @@ fn copy() {
     println!("Copy operation completed!");
 }
 
+// Prints a usage message
+fn _usage() {
+    let usage_message = String::from(
+        "This program is used for your batch of photos. It takes in one command line argument - \
+        either `rename` or `copy` to rename a batch of photos or copy the ones enumerated in a \
+        text file. Example: `$ ./pic copy`",
+    );
+    println!("{}", &usage_message);
+}
 
 /// read command line args and execute the correct function
 fn main() {
@@ -278,6 +277,7 @@ fn main() {
             copy()
         } else {
             println!("Unknown command line argument.");
+            _usage();
         }
     } else {
         println!("Too many command line arguments.");


### PR DESCRIPTION
Uses regex to be able to parse an image file into its prefix, index, and
extension. Goes through each photo and sees if the index matches what is
inside the file of numbers. Copies them if so.